### PR TITLE
add object message writer & various control stream message writers

### DIFF
--- a/src/control_stream.ts
+++ b/src/control_stream.ts
@@ -35,6 +35,7 @@ export class ControlStream {
       console.log("ClientSetup msg sent");
     } catch (error) {
       console.log("failed to send ClientSetup msg: ", error);
+      return;
     }
 
     const reader = this.reader.getReader();
@@ -49,6 +50,7 @@ export class ControlStream {
       console.log("handshake msg received: ", value);
     } catch (error) {
       console.log("failed to read handshake msg: ", error);
+      return;
     } finally {
       // TODO: Evaluate server setup message?
       reader.releaseLock();

--- a/src/control_stream.ts
+++ b/src/control_stream.ts
@@ -9,7 +9,7 @@ import type { Message, MessageEncoder } from "./messages";
 export class ControlStream {
   reader: ReadableStream<Message>;
   writer: WritableStream<MessageEncoder>;
-  onmessage?: (m: Message) => void; // leave cs msg handling to dev
+  onmessage?: (m: Message) => {};
 
   constructor(r: ReadableStream<Message>, w: WritableStream<MessageEncoder>) {
     this.reader = r;

--- a/src/control_stream.ts
+++ b/src/control_stream.ts
@@ -23,25 +23,18 @@ export class ControlStream {
       CURRENT_SUPPORTED_DRAFT.toString(16),
     );
 
-    const writer = this.writer.getWriter();
-
     try {
-      await writer.write(
-        new ClientSetupEncoder({
-          type: MessageType.ClientSetup,
-          versions: [CURRENT_SUPPORTED_DRAFT],
-          parameters: [
-            new ParameterEncoder({ type: 0, value: new Uint8Array([0x2]) }),
-          ],
-        }),
-      );
+      const m = new ClientSetupEncoder({
+        type: MessageType.ClientSetup,
+        versions: [CURRENT_SUPPORTED_DRAFT],
+        parameters: [
+          new ParameterEncoder({ type: 0, value: new Uint8Array([0x2]) }),
+        ],
+      });
+      await this.send(m);
       console.log("ClientSetup msg sent");
     } catch (error) {
       console.log("failed to send ClientSetup msg: ", error);
-      writer.releaseLock();
-      return;
-    } finally {
-      writer.releaseLock();
     }
 
     const reader = this.reader.getReader();

--- a/src/control_stream.ts
+++ b/src/control_stream.ts
@@ -35,7 +35,7 @@ export class ControlStream {
       console.log("ClientSetup msg sent");
     } catch (error) {
       console.log("failed to send ClientSetup msg: ", error);
-      return;
+      throw error;
     }
 
     const reader = this.reader.getReader();
@@ -50,7 +50,7 @@ export class ControlStream {
       console.log("handshake msg received: ", value);
     } catch (error) {
       console.log("failed to read handshake msg: ", error);
-      return;
+      throw error;
     } finally {
       // TODO: Evaluate server setup message?
       reader.releaseLock();

--- a/src/control_stream.ts
+++ b/src/control_stream.ts
@@ -66,7 +66,6 @@ export class ControlStream {
           break;
         }
         if (this.onmessage) {
-          console.log("control stream msg received in runReadLoop: ", value);
           this.onmessage(value);
         }
       }

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -470,7 +470,7 @@ export class ObjectStreamDecoder extends Decoder {
     }
 
     const mt = await this.readVarint();
-    console.log("decoding message type", mt);
+    // console.log("decoding message type", mt);
 
     if (mt === MessageType.ObjectStream) {
       controller.enqueue(await this.objectStream());

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -41,14 +41,14 @@ class Decoder {
   async read(
     buffer: Uint8Array,
     offset: number,
-    length: number
+    length: number,
   ): Promise<Uint8Array> {
     const reader = this.reader.getReader({ mode: "byob" });
     while (offset < length) {
       const buf = new Uint8Array(
         buffer.buffer,
         buffer.byteOffset + offset,
-        length - offset
+        length - offset,
       );
       const { value, done } = await reader.read(buf);
       if (done) {
@@ -86,9 +86,9 @@ class Decoder {
 
   async readVarint(): Promise<varint> {
     this.buffer = await this.read(this.buffer, 0, 1);
-    if (this.buffer.length !== 1) {
-      throw new Error("readVarint could not read first byte");
-    }
+    // if (this.buffer.length !== 1) {
+    //   throw new Error("readVarint could not read first byte");
+    // }
     const prefix = this.buffer[0]! >> 6;
     const length = 1 << prefix;
     let view = new DataView(this.buffer.buffer, 0, length);
@@ -305,7 +305,7 @@ class Decoder {
     const length = await this.readVarint();
     if (length > Number.MAX_VALUE) {
       throw new Error(
-        `cannot read more then ${Number.MAX_VALUE} bytes from stream`
+        `cannot read more then ${Number.MAX_VALUE} bytes from stream`,
       );
     }
     let objectStatus;
@@ -341,7 +341,7 @@ class Decoder {
     const length = await this.readVarint();
     if (length > Number.MAX_VALUE) {
       throw new Error(
-        `cannot read more then ${Number.MAX_VALUE} bytes from stream`
+        `cannot read more then ${Number.MAX_VALUE} bytes from stream`,
       );
     }
     let objectStatus;
@@ -359,7 +359,7 @@ class Decoder {
     const length = await this.readVarint();
     if (length > Number.MAX_VALUE) {
       throw new Error(
-        `cannot read more then ${Number.MAX_VALUE} bytes from stream`
+        `cannot read more then ${Number.MAX_VALUE} bytes from stream`,
       );
     }
     const data = await this.readN(<number>length);
@@ -371,7 +371,7 @@ class Decoder {
     const length = await this.readVarint();
     if (length > Number.MAX_VALUE) {
       throw new Error(
-        `cannot read more then ${Number.MAX_VALUE} bytes from stream`
+        `cannot read more then ${Number.MAX_VALUE} bytes from stream`,
       );
     }
     return {
@@ -436,7 +436,7 @@ export class ObjectStreamDecoder extends Decoder {
   }
 
   async pull(
-    controller: ReadableStreamDefaultController<ObjectMsg>
+    controller: ReadableStreamDefaultController<ObjectMsg>,
   ): Promise<void> {
     if (this.state === EncoderState.TrackStream) {
       const o = await this.streamHeaderTrackObject();

--- a/src/session.ts
+++ b/src/session.ts
@@ -186,6 +186,8 @@ export class Session {
     expires: number,
     groupOrder: number,
     contentExists: boolean,
+    finalGroup?: number,
+    finalObject?: number,
   ) {
     await this.controlStream.send(
       new SubscribeOkEncoder({
@@ -194,6 +196,8 @@ export class Session {
         expires: expires,
         groupOrder: groupOrder,
         contentExists: contentExists,
+        finalGroup: finalGroup,
+        finalObject: finalObject,
       }),
     );
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -144,6 +144,7 @@ export class Session {
     );
   }
 
+  //! moqtransport TODO
   async unannounce(namespace: string) {
     await this.controlStream.send(
       new UnannounceEncoder({

--- a/src/session.ts
+++ b/src/session.ts
@@ -268,7 +268,6 @@ export class Session {
         async write(chunk) {
           const writer = objectStream.getWriter();
           await writer.write(chunk);
-          console.log("object written to stream");
           writer.releaseLock();
         },
       });

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,6 +6,7 @@ import {
   MessageType,
   AnnounceEncoder,
   AnnounceOkEncoder,
+  UnannounceEncoder,
   SubscribeEncoder,
   SubscribeOkEncoder,
   SubscribeErrorEncoder,
@@ -138,6 +139,15 @@ export class Session {
         type: MessageType.Announce,
         namespace: namespace,
         parameters: [],
+      }),
+    );
+  }
+
+  async unannounce(namespace: string) {
+    await this.controlStream.send(
+      new UnannounceEncoder({
+        type: MessageType.Unannounce,
+        trackNamespace: namespace,
       }),
     );
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -10,12 +10,13 @@ import {
   SubscribeEncoder,
   SubscribeOkEncoder,
   SubscribeErrorEncoder,
+  SubscribeUpdateEncoder,
   UnsubscribeEncoder,
   SubscribeDoneEncoder,
   ObjectStreamEncoder,
 } from "./messages";
 import { Subscription } from "./subscription";
-import type { Message, ObjectMsg } from "./messages";
+import type { Message, ObjectMsg, Parameter } from "./messages";
 import type { varint } from "./varint";
 
 // so that tsup doesn't complain when producing the ts declaration file
@@ -258,6 +259,30 @@ export class Session {
         errorCode: errorCode,
         reasonPhrase: reasonPhrase,
         trackAlias: trackAlias,
+      }),
+    );
+  }
+
+  //! moqtransport TODO
+  async subscribeUpdate(
+    subscribeId: number,
+    startGroup: number,
+    startObject: number,
+    endGroup: number,
+    endObject: number,
+    subscriberPriority: number,
+    subscribeParameters: Parameter[],
+  ) {
+    await this.controlStream.send(
+      new SubscribeUpdateEncoder({
+        type: MessageType.SubscribeUpdate,
+        subscribeId: subscribeId,
+        startGroup: startGroup,
+        startObject: startObject,
+        endGroup: endGroup,
+        endObject: endObject,
+        subscriberPriority: subscriberPriority,
+        subscribeParameters: subscribeParameters,
       }),
     );
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,6 +6,7 @@ import {
   MessageType,
   SubscribeEncoder,
   UnsubscribeEncoder,
+  ObjectStreamEncoder,
 } from "./messages";
 import { Subscription } from "./subscription";
 import type { Message, ObjectMsg } from "./messages";
@@ -117,6 +118,24 @@ export class Session {
       await writer.write(value);
       writer.releaseLock();
     }
+  }
+
+  async writeObjUniStream(subscribeId: number, trackAlias: number, groupId: number, objectId: number, publisherPriority: number, objectStatus: number, objectPayload: Uint8Array) {
+    const objectStream = await this.conn.createUnidirectionalStream();
+    const writer = objectStream.getWriter();
+    await writer.write(
+      new ObjectStreamEncoder({
+        type: MessageType.ObjectStream,
+        subscribeId: subscribeId,
+        trackAlias: trackAlias,
+        groupId: groupId,
+        objectId: objectId,
+        publisherPriority: publisherPriority,
+        objectStatus: objectStatus,
+        objectPayload: objectPayload,
+      }),
+    );
+    await objectStream.close();
   }
 
   async handle(m: Message) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -98,7 +98,7 @@ export class Session {
 
   // @ts-ignore
   async readIncomingUniStream(stream: WebTransportReceiveStream) {
-    console.log("got stream");
+    // console.log("got stream");
     const messageStream = new ReadableStream<ObjectMsg>(
       new ObjectStreamDecoder(stream),
     );
@@ -106,7 +106,7 @@ export class Session {
     for (;;) {
       const { value, done } = await reader.read();
       if (done) {
-        console.log("stream closed");
+        // console.log("stream closed");
         break;
       }
       // console.log("got object", value);


### PR DESCRIPTION
- session.ts
	- obj msg writer writes obj msgs. It's a returned function / closure of `subscribeOk()`, it's more intuitive to do so, now the publisher needs to `ANNOUNCE` ns then the subscriber subscribes to its track, and the publisher replies with `subscribeOk()` to indicate subscriber's successful subscription, then the publisher gets this write obj msg function from the `subscribeOk()` function's returned value(it's a function in this case) and use it to write obj msgs.
		- usage exp:
			```javascript
			let writeObjUniStream = await session.subscribeOk(Number(m.subscribeId), 0, 1, false);
			await writeObjUniStream(Number(m.subscribeId), Number(m.trackAlias), 0, 0, 0, 0, catalogBytes);
			```
	- add control messages: `announce()`, `unannounce()`(moqtransport TODO), `announceOk()`, `subscribeOk()`, `subscribeError()`, `subscribeUpdate()`(moqtransport TODO), `subscribeDone()`

- decoder.ts
	- `this.buffer.length` is always 8 from `this.read()` Promise (checked by logging)
	- the read functions in Decoder class may need revision, but commenting out if statement makes it work (verified) ATM:
		```javascript
		if (this.buffer.length !== 1) {
			throw new Error("readVarint could not read first byte");
		}
		```
- control_stream.ts
	- surround with try-catch blocks to catch errors